### PR TITLE
Dictionary exception

### DIFF
--- a/resources/one-off-dictionary.txt
+++ b/resources/one-off-dictionary.txt
@@ -1,2 +1,2 @@
 word	file	lines
-Anexception	Untitled.Rmd	16
+fyi	04-instructors.Rmd	0

--- a/resources/one-off-dictionary.txt
+++ b/resources/one-off-dictionary.txt
@@ -1,0 +1,2 @@
+word	file	lines
+Anexception	Untitled.Rmd	16

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -16,6 +16,10 @@ root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 # Read in dictionary
 dictionary <- readLines(file.path(root_dir, 'resources', 'dictionary.txt'))
 
+# Read in dictionary one-off exceptions
+one_off <- read_delim(file.path(root_dir, 'one-off-dictionary.txt'), delim = "\t")
+one_off$lines <- as.character(one_off$lines)
+
 # Add mysterious emoji joining character
 dictionary <- c(dictionary, spelling::spell_check_text("⬇️")$word)
 
@@ -26,7 +30,8 @@ files <- list.files(pattern = 'Rmd$', recursive = TRUE, full.names = TRUE)
 sp_errors <- spelling::spell_check_files(files, ignore = dictionary) %>%
   data.frame() %>%
   tidyr::unnest(cols = found) %>%
-  tidyr::separate(found, into = c("file", "lines"), sep = ":")
+  tidyr::separate(found, into = c("file", "lines"), sep = ":") %>%
+  dplyr::anti_join(one_off, by = c("word", "file"))
 
 # Print out how many spell check errors
 write(nrow(sp_errors), stdout())

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -17,7 +17,7 @@ root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 dictionary <- readLines(file.path(root_dir, 'resources', 'dictionary.txt'))
 
 # Read in dictionary one-off exceptions
-one_off <- readr::read_delim(file.path(root_dir, 'one-off-dictionary.txt'), delim = "\t")
+one_off <- readr::read_delim(file.path(root_dir, 'resources', 'one-off-dictionary.txt'), delim = "\t")
 one_off$lines <- as.character(one_off$lines)
 
 # Add mysterious emoji joining character

--- a/scripts/spell-check.R
+++ b/scripts/spell-check.R
@@ -17,7 +17,7 @@ root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
 dictionary <- readLines(file.path(root_dir, 'resources', 'dictionary.txt'))
 
 # Read in dictionary one-off exceptions
-one_off <- read_delim(file.path(root_dir, 'one-off-dictionary.txt'), delim = "\t")
+one_off <- readr::read_delim(file.path(root_dir, 'one-off-dictionary.txt'), delim = "\t")
 one_off$lines <- as.character(one_off$lines)
 
 # Add mysterious emoji joining character


### PR DESCRIPTION
This PR adds a "one-off" dictionary that ignores a certain word but only in a specific file. This can be adapted for specific line numbers, but it's probably best not to do that while things are still in flux. The one-off dictionary should have text added in a tab delimited fashion like so: 
```
word	file	lines
fyi	04-instructors.Rmd	0
<new word>	<filename.Rmd>	<line#-not important for now>
```