### PR TITLE
Add Carrie's fix to `.gitignore`docs/ .. makes rendering checks easier

### DIFF
--- a/.github/workflows/render-bookdown.yml
+++ b/.github/workflows/render-bookdown.yml
@@ -47,6 +47,7 @@ jobs:
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
           git add -A
+          git add --force docs/*
           git commit -m 'Render bookdown' || echo "No changes to commit"
           git push origin main || echo "No changes to push"
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ spell_check_results.tsv
 .RData
 .httr-oauth
 docker/git_token.txt
+
+# ignore built files
+docs/*
+


### PR DESCRIPTION
Resolves the same issue in DaSL_Course_Template_Bookdown as referred to [here](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/pull/117).
See Basecamp discussion [here](https://3.basecamp.com/4924233/buckets/21267314/todos/3850097310).
