### PR TITLE
Generalize child files

### DIFF
--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -273,38 +273,11 @@ Billing permissions on Terra can be confusing.  For this reason, **We recommend 
 
 ### Create a New Workspace
 
-1. [Launch Terra](https://anvil.terra.bio/#workspaces)
-1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
+```{r, child=c("_child_create_workspace.Rmd")}
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
-    ```
+```
 
-1. Click on the **plus icon** near the top of left of the page.
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspaces page.  The "+" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_69")
-    ```
-
-1. Name your Workspace and select the appropriate Billing Project.  **All activity in the Workspace will be charged to this Billing Project** (regardless of who conducted it).
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The text box labeled "Workspace name" and the drop-down menu labeled "Billing project" are highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_84")
-    ```
-
-1. If you are working with protected data, you can set the **Authorization Domain** to limit who can be added to your Workspace.  Note that the Authorization Domain cannot be changed after the Workspace is created (i.e. there is no way to make this Workspace shareable with a larger audience in the future).  Workspaces by default are only visible to people you specifically share them with.  Authorization domains add an extra layer of enforcement over privacy, but by nature make sharing more complicated.  We recommend using Authorization Domains in cases where it is extremely important and/or legally required that the data be kept private (e.g. protected patient data, industry data).  For data you would merely prefer not be shared with the world, we recommend relying on standard Workspace sharing permissions rather than Authorization Domains, as Authorization Domains can make future collaborations, publications, or other sharing complicated.
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The drop-down menu labeled "Authorization domain" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_91")
-    ```
-
-1. Click "Create Workspace".  The new workspace should now show up under your Workspaces.
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The "Create Workspace" button is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_97")
-    ```
-
-**To start, we recommend creating one Workspace for each lab member** (associated with that lab member’s Billing Project, if you have created separate Billing Projects for your lab members).  This will enable you and your lab members to familiarize yourself with Workspaces and decide how best to organize your work.  You can then create additional Workspaces as needed (there are no limits on the number of Workspaces).
+**To start, we recommend creating one Workspace for each lab member** (associated with that lab member’s Billing Project, with separate Billing Projects for your lab members).  This will enable you and your lab members to familiarize yourself with Workspaces and decide how best to organize your work.  You can then create additional Workspaces as needed (there are no limits on the number of Workspaces).
 
 ### Add Members to Workspaces
 

--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -187,67 +187,64 @@ You can set a single Budget for your entire lab, set up individual budgets for e
 
 1. Log in to the [Google Cloud Platform](https://console.cloud.google.com/) console using your Google ID.
 1. Navigate to [Billing](https://console.cloud.google.com/billing)
-    +
+
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
-```
-    + You may be automatically directed to view a specific Billing Account.  If you see information about a single account (other than the one you're interested in), you can get back to the list of all your Billing Accounts by clicking "Manage Billing Accounts" from the drop-down menu.
-    + 
-```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
-```
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+    ```
+
+1. You may be automatically directed to view a specific Billing Account.  If you see information about a single account (other than the one you're interested in), you can get back to the list of all your Billing Accounts by clicking "Manage Billing Accounts" from the drop-down menu.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
+    ```
 
 1. Click on the name of the Billing Account you want to set alerts for.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. A Billing Account name is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_5")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. A Billing Account name is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_5")
+    ```
 
 1. In the left-hand menu, click "Budgets & alerts".
-    + 
-```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the left-hand menu item "Budgets & alerts" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_11")
-```
+ 
+    ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the left-hand menu item "Budgets & alerts" highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_11")
+    ```
 
 1. Click "Create Budget".
-    + 
-```{r, echo=FALSE, fig.alt='Screenshot of the budgets and alerts page for a Google Cloud Billing Account. The "Create Budget" button highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_17")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the budgets and alerts page for a Google Cloud Billing Account. The "Create Budget" button highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_17")
+    ```
 
 1. Enter a name for your budget, and then choose what you want to monitor.  Click "Next".
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget scope for a Google Cloud Billing Account. Three things are highlighted:  1) the box for entering a "Name" for the budget, 2) the dropdown menu labeled "Projects" for selecting which Billing Projects are part of the budget, and 3) the "Next" button.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_24")
-```
 
+    ```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget scope for a Google Cloud Billing Account. Three things are highlighted:  1) the box for entering a "Name" for the budget, 2) the dropdown menu labeled "Projects" for selecting which Billing Projects are part of the budget, and 3) the "Next" button.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_24")
+    ```
 
 1. For Budget Type, select "Specified amount".  Enter the total budget amount for the month (you will set alerts at different thresholds in the next step).  Click "**Next**" (not "Finish").
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget amount for a Google Cloud Billing Account.  The drop-down menu labeled "Budget type" is highlighted and "Specified amount" is selected.  Also highlighted are the text box labeled "Target amount" and the "Next" button.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_32")
-```
 
+    ```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget amount for a Google Cloud Billing Account.  The drop-down menu labeled "Budget type" is highlighted and "Specified amount" is selected.  Also highlighted are the text box labeled "Target amount" and the "Next" button.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_32")
+    ```
 
 1. Enter the threshold amounts where you want to receive an alert.  We recommend starting with 50% and 90%.  You can set other alerts if you prefer.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget actions for a Google Cloud Billing Account.  The boxes for entering "Percent of budget" or "Amount" are highlighted.  The drop-down menu labeled "Trigger on" is highlighted and "Actual" is selected.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_40")
-```
 
+    ```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget actions for a Google Cloud Billing Account.  The boxes for entering "Percent of budget" or "Amount" are highlighted.  The drop-down menu labeled "Trigger on" is highlighted and "Actual" is selected.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_40")
+    ```
 
 1. Check the box for "Email alerts to billing admins and users".  Click "**Finish**".  Now you (as the owner and admin), along with anyone you added with admin or user privileges (e.g lab managers) will receive alerts when your lab members reach the specified spending thresholds.  These emails will be sent to the Gmail accounts associated with the Billing Account.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget alerts for a Google Cloud Billing Account.  The checkbox labeled "Email alerts to billing admins and users" is highligheted and checked.  The "Finish" button is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_44")
-```
 
+    ```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget alerts for a Google Cloud Billing Account.  The checkbox labeled "Email alerts to billing admins and users" is highligheted and checked.  The "Finish" button is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_44")
+    ```
 
 1. You can edit your budgets at any time by going to Billing > Budgets & alerts, and clicking on the name of the budget you want to edit.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Billing Account Budgets and alerts overview.  Four items are highlighted illustrating how to view and edit an existing budget: 1) The top-left "hamburger" button for extending the drop-down menu, 2) the drop-down menu item "Billing", 3) the submenu item "Budgets & alerts, 4) the name of a budget.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_55")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Billing Account Budgets and alerts overview.  Four items are highlighted illustrating how to view and edit an existing budget: 1) The top-left "hamburger" button for extending the drop-down menu, 2) the drop-down menu item "Billing", 3) the submenu item "Budgets & alerts, 4) the name of a budget.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_55")
+    ```
 
 ### View spend
 
@@ -277,37 +274,35 @@ Billing permissions on Terra can be confusing.  For this reason, **We recommend 
 ### Create a New Workspace
 
 1. [Launch Terra](https://anvil.terra.bio/#workspaces)
-1. In the drop-down menu on the left, navigate to "Workspaces".
-    + Click the triple bar in the top left corner to access the menu.
-    + Click "Workspaces".
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
-```
-1. Click on the **plus icon** near the top of left of the page.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspaces page.  The "+" is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_69")
-```
+1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
 
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
+    ```
+
+1. Click on the **plus icon** near the top of left of the page.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspaces page.  The "+" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_69")
+    ```
 
 1. Name your Workspace and select the appropriate Billing Project.  **All activity in the Workspace will be charged to this Billing Project** (regardless of who conducted it).
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The text box labeled "Workspace name" and the drop-down menu labeled "Billing project" are highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_84")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The text box labeled "Workspace name" and the drop-down menu labeled "Billing project" are highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_84")
+    ```
 
 1. If you are working with protected data, you can set the **Authorization Domain** to limit who can be added to your Workspace.  Note that the Authorization Domain cannot be changed after the Workspace is created (i.e. there is no way to make this Workspace shareable with a larger audience in the future).  Workspaces by default are only visible to people you specifically share them with.  Authorization domains add an extra layer of enforcement over privacy, but by nature make sharing more complicated.  We recommend using Authorization Domains in cases where it is extremely important and/or legally required that the data be kept private (e.g. protected patient data, industry data).  For data you would merely prefer not be shared with the world, we recommend relying on standard Workspace sharing permissions rather than Authorization Domains, as Authorization Domains can make future collaborations, publications, or other sharing complicated.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The drop-down menu labeled "Authorization domain" is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_91")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The drop-down menu labeled "Authorization domain" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_91")
+    ```
 
 1. Click "Create Workspace".  The new workspace should now show up under your Workspaces.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The "Create Workspace" button is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_97")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The "Create Workspace" button is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_97")
+    ```
 
 **To start, we recommend creating one Workspace for each lab member** (associated with that lab member’s Billing Project, if you have created separate Billing Projects for your lab members).  This will enable you and your lab members to familiarize yourself with Workspaces and decide how best to organize your work.  You can then create additional Workspaces as needed (there are no limits on the number of Workspaces).
 
@@ -316,46 +311,44 @@ leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_r
 Lab members must have logged in to Terra at least once before they can be added to your Billing Projects and Workspaces (they do not need to log in to Google Cloud Console).
 
 1. [Launch Terra](https://anvil.terra.bio/#workspaces)
-1. In the drop-down menu on the left, navigate to "Workspaces".
-    + Click the triple bar in the top left corner to access the menu.
-    + Click "Workspaces".
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
-```
 
-1. Click on the name of the Workspace to open the Workspace.
-    + Opening a Workspace does not cost anything.  Certain activities in the Workspace (such as running an analysis) will charge to the Workspace’s Billing Project.  Workspace management (e.g. adding and removing members, editing the description) does not cost money.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspace page.  The name of a Workspace is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_103")
-```
+1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
+    ```
+
+1. Click on the name of the Workspace to open the Workspace. Opening a Workspace does not cost anything.  Certain activities in the Workspace (such as running an analysis) will charge to the Workspace’s Billing Project.  Workspace management (e.g. adding and removing members, editing the description) does not cost money.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspace page.  The name of a Workspace is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_103")
+    ```
 
 1. Click the circle with 3 dots on the right hand side to open the Workspace management menu.  Click "Share"
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of an individual Terra Workspace dashboard page.  The button for extending the Workspaces\'s drop-down menu is highlighted, and the menu item "Share" is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_109")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of an individual Terra Workspace dashboard page.  The button for extending the Workspaces\'s drop-down menu is highlighted, and the menu item "Share" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_109")
+    ```
 
 1. Enter the email address of the user you want to share the Workspace with.  This must be the address associated with the account they are using to access Terra.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The text box labeled "User email" is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_116")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The text box labeled "User email" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_116")
+    ```
 
 1. Choose their permission level.  **We recommend adding lab members as Writers** to start.  This gives them permission to freely use the Workspace, (adding and removing data, conducting analyses, etc.) but prevents them from adding additional members who could charge to your Billing Project.
     + "Can compute" should be checked
     + "Can share" should **NOT** be checked
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The drop-down menu labeled with the email of the user you are sharing with is highlighted and the menu item "Writer" is selected.  The check box labeled "Can share" is annotated with the word "No" and is unchecked.  The checkbox labeled "Can compute" is annotated with the word "Yes" and is checked.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_128")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The drop-down menu labeled with the email of the user you are sharing with is highlighted and the menu item "Writer" is selected.  The check box labeled "Can share" is annotated with the word "No" and is unchecked.  The checkbox labeled "Can compute" is annotated with the word "Yes" and is checked.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_128")
+    ```
 
 1. Click "Save".  The user should now be able to see the Workspace when logged in to Terra.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The "Save" button is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_132")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The "Save" button is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_132")
+    ```
 
 ### User Access Levels and Permissions
 

--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -189,61 +189,61 @@ You can set a single Budget for your entire lab, set up individual budgets for e
 1. Navigate to [Billing](https://console.cloud.google.com/billing)
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
     ```
 
 1. You may be automatically directed to view a specific Billing Account.  If you see information about a single account (other than the one you're interested in), you can get back to the list of all your Billing Accounts by clicking "Manage Billing Accounts" from the drop-down menu.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
     ```
 
 1. Click on the name of the Billing Account you want to set alerts for.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. A Billing Account name is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_5")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_5")
     ```
 
 1. In the left-hand menu, click "Budgets & alerts".
  
     ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the left-hand menu item "Budgets & alerts" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_11")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_11")
     ```
 
 1. Click "Create Budget".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the budgets and alerts page for a Google Cloud Billing Account. The "Create Budget" button highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_17")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_17")
     ```
 
 1. Enter a name for your budget, and then choose what you want to monitor.  Click "Next".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget scope for a Google Cloud Billing Account. Three things are highlighted:  1) the box for entering a "Name" for the budget, 2) the dropdown menu labeled "Projects" for selecting which Billing Projects are part of the budget, and 3) the "Next" button.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_24")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_24")
     ```
 
 1. For Budget Type, select "Specified amount".  Enter the total budget amount for the month (you will set alerts at different thresholds in the next step).  Click "**Next**" (not "Finish").
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget amount for a Google Cloud Billing Account.  The drop-down menu labeled "Budget type" is highlighted and "Specified amount" is selected.  Also highlighted are the text box labeled "Target amount" and the "Next" button.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_32")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_32")
     ```
 
 1. Enter the threshold amounts where you want to receive an alert.  We recommend starting with 50% and 90%.  You can set other alerts if you prefer.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget actions for a Google Cloud Billing Account.  The boxes for entering "Percent of budget" or "Amount" are highlighted.  The drop-down menu labeled "Trigger on" is highlighted and "Actual" is selected.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_40")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_40")
     ```
 
 1. Check the box for "Email alerts to billing admins and users".  Click "**Finish**".  Now you (as the owner and admin), along with anyone you added with admin or user privileges (e.g lab managers) will receive alerts when your lab members reach the specified spending thresholds.  These emails will be sent to the Gmail accounts associated with the Billing Account.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the form for setting budget alerts for a Google Cloud Billing Account.  The checkbox labeled "Email alerts to billing admins and users" is highligheted and checked.  The "Finish" button is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_44")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_44")
     ```
 
 1. You can edit your budgets at any time by going to Billing > Budgets & alerts, and clicking on the name of the budget you want to edit.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Billing Account Budgets and alerts overview.  Four items are highlighted illustrating how to view and edit an existing budget: 1) The top-left "hamburger" button for extending the drop-down menu, 2) the drop-down menu item "Billing", 3) the submenu item "Budgets & alerts, 4) the name of a budget.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_55")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_55")
     ```
 
 ### View spend
@@ -288,25 +288,25 @@ Lab members must have logged in to Terra at least once before they can be added 
 1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
     ```
 
 1. Click on the name of the Workspace to open the Workspace. Opening a Workspace does not cost anything.  Certain activities in the Workspace (such as running an analysis) will charge to the Workspace’s Billing Project.  Workspace management (e.g. adding and removing members, editing the description) does not cost money.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspace page.  The name of a Workspace is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_103")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_103")
     ```
 
 1. Click the circle with 3 dots on the right hand side to open the Workspace management menu.  Click "Share"
 
     ```{r, echo=FALSE, fig.alt='Screenshot of an individual Terra Workspace dashboard page.  The button for extending the Workspaces\'s drop-down menu is highlighted, and the menu item "Share" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_109")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_109")
     ```
 
 1. Enter the email address of the user you want to share the Workspace with.  This must be the address associated with the account they are using to access Terra.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The text box labeled "User email" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_116")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_116")
     ```
 
 1. Choose their permission level.  **We recommend adding lab members as Writers** to start.  This gives them permission to freely use the Workspace, (adding and removing data, conducting analyses, etc.) but prevents them from adding additional members who could charge to your Billing Project.
@@ -314,13 +314,13 @@ Lab members must have logged in to Terra at least once before they can be added 
     + "Can share" should **NOT** be checked
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The drop-down menu labeled with the email of the user you are sharing with is highlighted and the menu item "Writer" is selected.  The check box labeled "Can share" is annotated with the word "No" and is unchecked.  The checkbox labeled "Can compute" is annotated with the word "Yes" and is checked.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_128")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_128")
     ```
 
 1. Click "Save".  The user should now be able to see the Workspace when logged in to Terra.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The "Save" button is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_132")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_132")
     ```
 
 ### User Access Levels and Permissions

--- a/_child_add_member_to_google_billing_account.Rmd
+++ b/_child_add_member_to_google_billing_account.Rmd
@@ -6,29 +6,29 @@ To add a member to a Billing Project:
 1. Navigate to [Billing](https://console.cloud.google.com/billing)
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
     ```
 
 1. You may be automatically directed to view a specific Billing Account.  If you see information about a single account rather than a list of your Billing Accounts, you can get back to the list by clicking "Manage Billing Accounts" from the drop-down menu.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
     ```
 
 1. Check the box next to the Billing Account you wish to add a member to, click "ADD MEMBER".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. The checkbox next to the name of a Billing Account is checked and highlighted, and the "Add Member" button is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_178")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_178")
     ```
 
 1. Enter their Google ID in the text box. In the drop-down menu, mouse over Billing, then choose the appropriate role.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. In the drop-down menu labeled "Select a Role", the item "Billing" and the submenu item "Billing Account Viewer" are highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_185")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_185")
     ```
 
 1. Click "SAVE".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The Save button is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_192")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_192")
     ```

--- a/_child_add_member_to_google_billing_account.Rmd
+++ b/_child_add_member_to_google_billing_account.Rmd
@@ -4,30 +4,31 @@ To add a member to a Billing Project:
   
 1. Log in to the [Google Cloud Platform](https://console.cloud.google.com/) console using your Google ID.
 1. Navigate to [Billing](https://console.cloud.google.com/billing)
-    +
-  ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
-```
-    + You may be automatically directed to view a specific Billing Account.  If you see information about a single account rather than a list of your Billing Accounts, you can get back to the list by clicking "Manage Billing Accounts" from the drop-down menu.
-    + 
-  ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+    ```
+
+1. You may be automatically directed to view a specific Billing Account.  If you see information about a single account rather than a list of your Billing Accounts, you can get back to the list by clicking "Manage Billing Accounts" from the drop-down menu.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
+    ```
 
 1. Check the box next to the Billing Account you wish to add a member to, click "ADD MEMBER".
-    +
-  ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. The checkbox next to the name of a Billing Account is checked and highlighted, and the "Add Member" button is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_178")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. The checkbox next to the name of a Billing Account is checked and highlighted, and the "Add Member" button is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_178")
+    ```
 
 1. Enter their Google ID in the text box. In the drop-down menu, mouse over Billing, then choose the appropriate role.
-    +
-  ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. In the drop-down menu labeled "Select a Role", the item "Billing" and the submenu item "Billing Account Viewer" are highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_185")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. In the drop-down menu labeled "Select a Role", the item "Billing" and the submenu item "Billing Account Viewer" are highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_185")
+    ```
 
 1. Click "SAVE".
-    +
-  ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The Save button is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_192")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The Save button is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_192")
+    ```

--- a/_child_add_terra_to_google_billing_account.Rmd
+++ b/_child_add_terra_to_google_billing_account.Rmd
@@ -6,29 +6,29 @@ Terra needs to be added as a "Billing Account User":
 1. Navigate to [Billing](https://console.cloud.google.com/billing)
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
     ```
 
 1. You may be automatically directed to view a specific Billing Account.  If you see information about a single account rather than a list of your Billing Accounts, you can get back to the list by clicking "Manage Billing Accounts" from the drop-down menu.
  
     ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
     ```
 
 1. Check the box next to the Billing Account you wish to add Terra to, click "ADD MEMBER".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. The checkbox next to the name of a Billing Account is checked and highlighted, and the "Add Member" button is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_178")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_178")
     ```
 
 1. Enter `terra-billing@terra.bio` in the text box.  In the drop-down menu, mouse over Billing, then choose "**Billing Account User**".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The text box is highlighted and has been filled in with "terra-billing@terra.bio".  In the drop-down menu labeled "Select a Role", the item "Billing" and the submenu item "Billing Account User" are highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_203")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_203")
     ```
 
 1. Click "SAVE".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The Save button is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_207")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_207")
     ```

--- a/_child_add_terra_to_google_billing_account.Rmd
+++ b/_child_add_terra_to_google_billing_account.Rmd
@@ -4,30 +4,31 @@ Terra needs to be added as a "Billing Account User":
 
 1. Log in to the [Google Cloud Platform](https://console.cloud.google.com/) console using your Google ID.
 1. Navigate to [Billing](https://console.cloud.google.com/billing)
-    +
+
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
-```
-    + You may be automatically directed to view a specific Billing Account.  If you see information about a single account rather than a list of your Billing Accounts, you can get back to the list by clicking "Manage Billing Accounts" from the drop-down menu.
-    + 
-```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
-```
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+    ```
+
+1. You may be automatically directed to view a specific Billing Account.  If you see information about a single account rather than a list of your Billing Accounts, you can get back to the list by clicking "Manage Billing Accounts" from the drop-down menu.
+ 
+    ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
+    ```
 
 1. Check the box next to the Billing Account you wish to add Terra to, click "ADD MEMBER".
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. The checkbox next to the name of a Billing Account is checked and highlighted, and the "Add Member" button is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_178")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. The checkbox next to the name of a Billing Account is checked and highlighted, and the "Add Member" button is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_178")
+    ```
 
 1. Enter `terra-billing@terra.bio` in the text box.  In the drop-down menu, mouse over Billing, then choose "**Billing Account User**".
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The text box is highlighted and has been filled in with "terra-billing@terra.bio".  In the drop-down menu labeled "Select a Role", the item "Billing" and the submenu item "Billing Account User" are highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_203")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The text box is highlighted and has been filled in with "terra-billing@terra.bio".  In the drop-down menu labeled "Select a Role", the item "Billing" and the submenu item "Billing Account User" are highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_203")
+    ```
 
 1. Click "SAVE".
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The Save button is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_207")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialogue box for adding a member to a Google Cloud Billing Accounts. The Save button is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_207")
+    ```

--- a/_child_create_google_billing_account.Rmd
+++ b/_child_create_google_billing_account.Rmd
@@ -1,28 +1,29 @@
-1. Log in to the [Google Cloud Platform](https://console.cloud.google.com/) console using your Google ID.
-    + **Make sure to use the same Google account ID you use to log into Terra.**
-1. If you are a first time user, don’t forget to claim your free credits!
-    + If you haven't been to the console before, once you accept the Terms of Service you will be greeted with an invitation to "Try for Free."
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console with the "Try for Free" button highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd5c49c5c55_0_152")
-```
-    + Follow the instructions to sign up for a Billing Account and get your credits.
-        + Choose “Individual Account”.  This “billing account” is just for managing billing, so you don’t need to be able to add your lab members.
-        + You will need to give either a credit card or bank account for security. Don't worry! **You won't be billed until you explicitly turn on automatic billing**.
-        +
-```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Billing Account Setup, with "Individual Account" highlighted.  Also highlighted is text stating "You won\'t be charged unless you manually upgrade to a paid account."'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_145")
-```
+1. Log in to the [Google Cloud Platform](https://console.cloud.google.com/) console using your Google ID. **Make sure to use the same Google account ID you use to log into Terra.**  
+
+1. If you are a first time user, don’t forget to claim your free credits! If you haven't been to the console before, once you accept the Terms of Service you will be greeted with an invitation to "Try for Free."
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console with the "Try for Free" button highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd5c49c5c55_0_152")
+    ```
+
+1. Follow the instructions to sign up for a Billing Account and get your credits. 
+
+1. Choose “Individual Account”. This “billing account” is just for managing billing, so you don’t need to be able to add your lab members. You will need to give either a credit card or bank account for security. Don't worry! **You won't be billed until you explicitly turn on automatic billing**.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Billing Account Setup, with "Individual Account" highlighted.  Also highlighted is text stating "You won\'t be charged unless you manually upgrade to a paid account."'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_145")
+    ```
 
 1. You can view and edit your new Billing Account, by selecting “Billing” from the left-hand menu, or going direction to the billing console [console.cloud.google.com/billing](https://console.cloud.google.com/billing) 
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console dropdown menu, with "Billing" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
-```
-    + Clicking on the Billing Account name will allow you to manage the account, including accessing reports, setting alerts, and managing payments and billing.  We will cover account management in greater detail below.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console Billing Page, with the name of the new billing account highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_160")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console dropdown menu, with "Billing" highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+    ```
+
+1. Clicking on the Billing Account name will allow you to manage the account, including accessing reports, setting alerts, and managing payments and billing.  We will cover account management in greater detail below.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console Billing Page, with the name of the new billing account highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_160")
+    ```
 
 At any point, you can create additional Billing Accounts using the **Create Account** button.  We recommend creating a new Billing Account for each funding source.

--- a/_child_create_google_billing_account.Rmd
+++ b/_child_create_google_billing_account.Rmd
@@ -3,7 +3,7 @@
 1. If you are a first time user, don’t forget to claim your free credits! If you haven't been to the console before, once you accept the Terms of Service you will be greeted with an invitation to "Try for Free."
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console with the "Try for Free" button highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd5c49c5c55_0_152")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd5c49c5c55_0_152")
     ```
 
 1. Follow the instructions to sign up for a Billing Account and get your credits. 
@@ -11,19 +11,19 @@
 1. Choose “Individual Account”. This “billing account” is just for managing billing, so you don’t need to be able to add your lab members. You will need to give either a credit card or bank account for security. Don't worry! **You won't be billed until you explicitly turn on automatic billing**.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Billing Account Setup, with "Individual Account" highlighted.  Also highlighted is text stating "You won\'t be charged unless you manually upgrade to a paid account."'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_145")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_145")
     ```
 
 1. You can view and edit your new Billing Account, by selecting “Billing” from the left-hand menu, or going direction to the billing console [console.cloud.google.com/billing](https://console.cloud.google.com/billing) 
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console dropdown menu, with "Billing" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
     ```
 
 1. Clicking on the Billing Account name will allow you to manage the account, including accessing reports, setting alerts, and managing payments and billing.  We will cover account management in greater detail below.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console Billing Page, with the name of the new billing account highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_160")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_160")
     ```
 
 At any point, you can create additional Billing Accounts using the **Create Account** button.  We recommend creating a new Billing Account for each funding source.

--- a/_child_create_terra_billing_project.Rmd
+++ b/_child_create_terra_billing_project.Rmd
@@ -3,13 +3,13 @@
 1. In the drop-down menu on the left, navigate to "Billing". Click the triple bar in the top left corner to access the menu. Click the arrow next to your name to expand the menu, then click "Billing".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Terra drop-down menu.  Three items are highlighted: 1) the "hamburger" button for extending the drop-down menu, 2) the arrow next to your username, for extending the drop-down submenu, and 3) the submenu item "Billing".'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_222")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_222")
     ```
 
 1. On the Billing page, click the "+ CREATE" button to create a new Billing Project. If prompted, select the Google account to use.  Make sure to use the same Google account that you used to set up Google Billing. If prompted, give Terra permission to manage Google Cloud Platform billing accounts.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Terra Billing Page.  The "plus" button next to "Billing Projects" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_226")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_226")
     ```
 
 1. Enter a unique name for your Terra Billing Project and select the appropriate Google Billing Account. The name of the Terra Billing Project must:
@@ -20,5 +20,5 @@
     + Be unique across all Google Billing Projects
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Terra Add Billing Project dialog box.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_230")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_230")
     ```

--- a/_child_create_terra_billing_project.Rmd
+++ b/_child_create_terra_billing_project.Rmd
@@ -1,30 +1,24 @@
-1. [Launch Terra](https://anvil.terra.bio/#workspaces) and sign in with your Google account.  **Make sure to use the same Google account that you used to set up Google Billing.**
-    + If this is your first time logging in to Terra, you will need to accept the Terms of Service.
-1. In the drop-down menu on the left, navigate to “Billing”.
-    + Click the triple bar in the top left corner to access the menu.
-    + Click the arrow next to your name to expand the menu.
-    + Click Billing.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the Terra drop-down menu.  Three items are highlighted: 1) the "hamburger" button for extending the drop-down menu, 2) the arrow next to your username, for extending the drop-down submenu, and 3) the submenu item "Billing".'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_222")
-```
+1. [Launch Terra](https://anvil.terra.bio/#workspaces) and sign in with your Google account.  **Make sure to use the same Google account that you used to set up Google Billing.** If this is your first time logging in to Terra, you will need to accept the Terms of Service.
 
-1. On the Billing page, click the **plus icon** to create a new Billing Project.
-    + If prompted, select the Google account to use.  Make sure to use the same Google account that you used to set up Google Billing.
-    + If prompted, give Terra permission to manage Google Cloud Platform billing accounts.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the Terra Billing Page.  The "plus" button next to "Billing Projects" is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_226")
-```
+1. In the drop-down menu on the left, navigate to "Billing". Click the triple bar in the top left corner to access the menu. Click the arrow next to your name to expand the menu, then click "Billing".
 
-1. Enter a unique name for your Terra Billing Project and select the appropriate Google Billing Account.
-    + The name of the Terra Billing Project must:
-        + Only contain lowercase letters, numbers and hyphens
-        + Start with a lowercase letter
-        + Not end with a hyphen
-        + Be between 6 and 30 characters
-        + Be unique across all Google Billing Projects
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the Terra Add Billing Project dialog box.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_230")
-```
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Terra drop-down menu.  Three items are highlighted: 1) the "hamburger" button for extending the drop-down menu, 2) the arrow next to your username, for extending the drop-down submenu, and 3) the submenu item "Billing".'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_222")
+    ```
+
+1. On the Billing page, click the "+ CREATE" button to create a new Billing Project. If prompted, select the Google account to use.  Make sure to use the same Google account that you used to set up Google Billing. If prompted, give Terra permission to manage Google Cloud Platform billing accounts.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Terra Billing Page.  The "plus" button next to "Billing Projects" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_226")
+    ```
+
+1. Enter a unique name for your Terra Billing Project and select the appropriate Google Billing Account. The name of the Terra Billing Project must:
+    + Only contain lowercase letters, numbers and hyphens
+    + Start with a lowercase letter
+    + Not end with a hyphen
+    + Be between 6 and 30 characters
+    + Be unique across all Google Billing Projects
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Terra Add Billing Project dialog box.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_230")
+    ```

--- a/_child_create_workspace.Rmd
+++ b/_child_create_workspace.Rmd
@@ -1,0 +1,31 @@
+1. [Launch Terra](https://anvil.terra.bio/#workspaces)
+
+1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
+    ```
+
+1. Click on the **plus icon** near the top of left of the page.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspaces page.  The "+" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_69")
+    ```
+
+1. Name your Workspace and select the appropriate Billing Project.  **All activity in the Workspace will be charged to this Billing Project** (regardless of who conducted it).
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The text box labeled "Workspace name" and the drop-down menu labeled "Billing project" are highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_84")
+    ```
+
+1. If you are working with protected data, you can set the **Authorization Domain** to limit who can be added to your Workspace.  Note that the Authorization Domain cannot be changed after the Workspace is created (i.e. there is no way to make this Workspace shareable with a larger audience in the future).  Workspaces by default are only visible to people you specifically share them with.  Authorization domains add an extra layer of enforcement over privacy, but by nature make sharing more complicated.  We recommend using Authorization Domains in cases where it is extremely important and/or legally required that the data be kept private (e.g. protected patient data, industry data).  For data you would merely prefer not be shared with the world, we recommend relying on standard Workspace sharing permissions rather than Authorization Domains, as Authorization Domains can make future collaborations, publications, or other sharing complicated.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The drop-down menu labeled "Authorization domain" is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_91")
+    ```
+
+1. Click "Create Workspace".  The new workspace should now show up under your Workspaces.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The "Create Workspace" button is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_97")
+    ```

--- a/_child_create_workspace.Rmd
+++ b/_child_create_workspace.Rmd
@@ -3,29 +3,29 @@
 1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
     ```
 
 1. Click on the **plus icon** near the top of left of the page.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspaces page.  The "+" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_69")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_69")
     ```
 
 1. Name your Workspace and select the appropriate Billing Project.  **All activity in the Workspace will be charged to this Billing Project** (regardless of who conducted it).
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The text box labeled "Workspace name" and the drop-down menu labeled "Billing project" are highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_84")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_84")
     ```
 
 1. If you are working with protected data, you can set the **Authorization Domain** to limit who can be added to your Workspace.  Note that the Authorization Domain cannot be changed after the Workspace is created (i.e. there is no way to make this Workspace shareable with a larger audience in the future).  Workspaces by default are only visible to people you specifically share them with.  Authorization domains add an extra layer of enforcement over privacy, but by nature make sharing more complicated.  We recommend using Authorization Domains in cases where it is extremely important and/or legally required that the data be kept private (e.g. protected patient data, industry data).  For data you would merely prefer not be shared with the world, we recommend relying on standard Workspace sharing permissions rather than Authorization Domains, as Authorization Domains can make future collaborations, publications, or other sharing complicated.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The drop-down menu labeled "Authorization domain" is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_91")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_91")
     ```
 
 1. Click "Create Workspace".  The new workspace should now show up under your Workspaces.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The "Create Workspace" button is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_97")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_97")
     ```

--- a/_child_view_google_spending.Rmd
+++ b/_child_view_google_spending.Rmd
@@ -8,42 +8,43 @@ The Google Billing console displays information by Billing Account.  To view spe
 1. Log in to the [Google Cloud Platform](https://console.cloud.google.com/) console using your Google ID.
 
 1. Navigate to [Billing](https://console.cloud.google.com/billing)
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
-```
-    + You may be automatically directed to view a specific Billing Account.  If you see information about a single account (other than the one you're interested in), you can get back to the list of all your Billing Accounts by clicking "Manage Billing Accounts" from the drop-down menu.
-    + 
-```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+    ```
+
+1. You may be automatically directed to view a specific Billing Account.  If you see information about a single account (other than the one you're interested in), you can get back to the list of all your Billing Accounts by clicking "Manage Billing Accounts" from the drop-down menu.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
+    ```
 
 1. Click on the name of the Billing Account for the project you want to view.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. A Billing Account name is highlighted.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_5")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. A Billing Account name is highlighted.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_5")
+    ```
 
 1. Look at the top of the **Overview** tab to see your month-to-date spending.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Overview.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_0")
-```
+    
+    ```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Overview.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_0")
+    ```
 
 1. Scroll further down the **Overview** tab to show your top projects.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account top projects.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_4")
-```
+    
+    ```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account top projects.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_4")
+    ```
 
 1. Click on the **Reports** tab to see more detailed information about each of your billing projects.  This is probably the most useful tab for exploring costs of individual projects over time.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Reports tab.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_8")
-```
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Reports tab.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_8")
+    ```
 
 1. Click on the **Cost table** tab to obtain a convenient table of spending per project.
-    +
-```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Cost table tab.'}
-leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_12")
-```
+    
+    ```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Cost table tab.'}
+    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_12")
+    ```

--- a/_child_view_google_spending.Rmd
+++ b/_child_view_google_spending.Rmd
@@ -10,41 +10,41 @@ The Google Billing console displays information by Billing Account.  To view spe
 1. Navigate to [Billing](https://console.cloud.google.com/billing)
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console drop-down menu, with "Billing" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_153")
     ```
 
 1. You may be automatically directed to view a specific Billing Account.  If you see information about a single account (other than the one you're interested in), you can get back to the list of all your Billing Accounts by clicking "Manage Billing Accounts" from the drop-down menu.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of an individual Google Cloud Billing Account with the drop-down menu item "Manage Billing Accounts" highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gd84a304855_0_167")
     ```
 
 1. Click on the name of the Billing Account for the project you want to view.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Google Cloud Billing Accounts Overview. A Billing Account name is highlighted.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_5")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_5")
     ```
 
 1. Look at the top of the **Overview** tab to see your month-to-date spending.
     
     ```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Overview.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_0")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_0")
     ```
 
 1. Scroll further down the **Overview** tab to show your top projects.
     
     ```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account top projects.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_4")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_4")
     ```
 
 1. Click on the **Reports** tab to see more detailed information about each of your billing projects.  This is probably the most useful tab for exploring costs of individual projects over time.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Reports tab.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_8")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_8")
     ```
 
 1. Click on the **Cost table** tab to obtain a convenient table of spending per project.
     
     ```{r, echo=FALSE, fig.alt='Screenshot of a Google Cloud Billing Account Cost table tab.'}
-    leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_12")
+leanbuild::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.ge3b5f92447_0_12")
     ```


### PR DESCRIPTION
This PR mainly makes some aesthetic changes. This includes:

- Modifying the screenshots in the child files to not have bullet points (this doesn't look great)
- Moving instructions about creating a Workspace to their own child file, which will be helpful later

Not part of the PR per se, but updated the google slides so that the screenshots for making a billing project are a little more generalized (for non-PIs)