### PR TITLE
adding edit button

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -14,4 +14,6 @@ bookdown::gitbook:
        <p style="text-align:center;"> <a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started" target="blank" > This content was published with</a> <a href="https://bookdown.org/" target="blank"> bookdown by:</a> </p>
        <p style="text-align:center;"> <a href="http://jhudatascience.org/"> The Johns Hopkins Data Science Lab </a></p>
        <p style="text-align:center; font-size: 12px;"> <a href="https://github.com/rstudio4edu/rstudio4edu-book/"> Style adapted from: rstudio4edu-book </a> <a href ="https://creativecommons.org/licenses/by/2.0/"> (CC-BY 2.0) </a></p>
+    edit: https://github.com/jhudsl/AnVIL_Book_Getting_Started/edit/main/%s
   split_by: section
+  


### PR DESCRIPTION
Trying out the gitbook edit button.

It doesn't seem to show up in the rendered previews below; it's working when I run bookdown::render_book() on my computer (using the Docker image)

Is this something we want, or not worth it?

<img width="985" alt="Screen Shot 2021-11-10 at 2 40 46 PM" src="https://user-images.githubusercontent.com/13210811/141183625-d39a9afd-8d85-4b94-a1b0-1992815cb435.png">
