### PR TITLE
update workspace slide links

### DIFF
--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -242,16 +242,16 @@ Lab members can be added to a Workspace with a few different permission levels:
 - **Writers** can make edits and run analyses (i.e. they **can spend your money**)
 - **Owners** can make edits and run analyses and can also manage the permissions of other users (i.e. they **can enable others to spend your money**)
 
-Managing permissions for a Workspace has important implications:
-
-- **Billing**: Terra charges are associated with Workspaces rather than users.  Any billable activity that takes place in a given Workspace will be charged to the associated Billing Project, regardless of who conducted the activity.  If there are multiple users with permission to compute, it is impossible to tell who conducted the activity.
-- **Data access**: Especially when working with protected data, it’s important to ensure that users have proper authorization to view the data before giving them access to a Workspace containing the data.  Terra provides **Authorization Domains** to assist with this.
-
 ```{r, echo=FALSE, fig.alt='Table summarizing Workspace permission levels.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1hhdPNfuAhbwkl5LlNVlJiCIx_rbzVp3jSJJeksqiR5I/edit#slide=id.g117dd5f15db_0_584")
 ```
 
 More details about the permissions associated with each Access Level can be found in the [Terra documentation](https://support.terra.bio/hc/en-us/articles/360025851892-Reader-writer-or-owner-Workspace-access-controls-explained).
+
+Managing permissions for a Workspace has important implications:
+
+- **Billing**: Terra charges are associated with Workspaces rather than users.  Any billable activity that takes place in a given Workspace will be charged to the associated Billing Project, regardless of who conducted the activity.  If there are multiple users with permission to compute, it is impossible to tell who conducted the activity.
+- **Data access**: Especially when working with protected data, it’s important to ensure that users have proper authorization to view the data before giving them access to a Workspace containing the data.  Terra provides **Authorization Domains** to assist with this.
 
 In general we recommend:
 

--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -255,7 +255,7 @@ Managing permissions for a Workspace has important implications:
 
 In general we recommend:
 
-- **Writers: Lab members who need permission to compute** (and charge to your Billing Project).  This gives them permission to freely use the Workspace, (adding and removing data, conducting analyses, etc.) but prevents them from adding additional members who could charge to your Billing Project, ensuring you have control over *who* is doing the spending.
+- **Writers: Lab members who need permission to compute** (and charge to your Billing Project).  This gives them permission to freely use the Workspace, (adding and removing data, conducting analyses, etc.) but prevents them from adding additional members who could charge to your Billing Project. This ensures you have control over *who* is doing the spending.
 - **Readers: All other users** (i.e. users who need to see the Workspace but should not charge to your Billing Project).  Readers can always “clone” the Workspace (creating a copy of it associated with their own Billing Project) if they want to run computations themselves.
 - If working with protected data, take advantage of Authorization Domains to increase security.
 

--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -236,64 +236,36 @@ Billing permissions on Terra can be confusing.  For this reason, **We recommend 
 
 Lab members must have logged in to Terra at least once before they can be added to your Billing Projects and Workspaces (they do not need to log in to Google Cloud Console).  You can send lab members to the [Data Analysts] guide for instructions on how they can sign up and start working on AnVIL.
 
-1. [Launch Terra](https://anvil.terra.bio/#workspaces)
+Lab members can be added to a Workspace with a few different permission levels:
 
-1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
+- **Readers** can view the Workspace but not make edits or run analyses (i.e. they **cannot spend your money**)
+- **Writers** can make edits and run analyses (i.e. they **can spend your money**)
+- **Owners** can make edits and run analyses and can also manage the permissions of other users (i.e. they **can enable others to spend your money**)
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
-    ```
+Managing permissions for a Workspace has important implications:
 
-1. Click on the name of the Workspace to open the Workspace. Opening a Workspace does not cost anything.  Certain activities in the Workspace (such as running an analysis) will charge to the Workspace’s Billing Project.  Workspace management (e.g. adding and removing members, editing the description) does not cost money.
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspace page.  The name of a Workspace is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_103")
-    ```
-
-1. Click the circle with 3 dots on the right hand side to open the Workspace management menu.  Click "Share"
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of an individual Terra Workspace dashboard page.  The button for extending the Workspaces\'s drop-down menu is highlighted, and the menu item "Share" is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_109")
-    ```
-
-1. Enter the email address of the user you want to share the Workspace with.  This must be the address associated with the account they are using to access Terra.
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The text box labeled "User email" is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_116")
-    ```
-
-1. Choose their permission level.  **We recommend adding lab members as Writers** to start.  This gives them permission to freely use the Workspace, (adding and removing data, conducting analyses, etc.) but prevents them from adding additional members who could charge to your Billing Project.
-    + "Can compute" should be checked
-    + "Can share" should **NOT** be checked
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The drop-down menu labeled with the email of the user you are sharing with is highlighted and the menu item "Writer" is selected.  The check box labeled "Can share" is annotated with the word "No" and is unchecked.  The checkbox labeled "Can compute" is annotated with the word "Yes" and is checked.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_128")
-    ```
-
-1. Click "Save".  The user should now be able to see the Workspace when logged in to Terra.
-
-    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The "Save" button is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_132")
-    ```
-
-### User Access Levels and Permissions
-
-Managing permissions for your Workspace has important implications:
-
-- **Billing**: Terra charges are associated with Workspaces rather than users.  Any billable activity that takes place in a given Workspace will be charged to the associated Billing Project, regardless of who conducted the activity.  If there are multiple users with permission to compute, you won’t be able to tell who conducted the activity.
+- **Billing**: Terra charges are associated with Workspaces rather than users.  Any billable activity that takes place in a given Workspace will be charged to the associated Billing Project, regardless of who conducted the activity.  If there are multiple users with permission to compute, it is impossible to tell who conducted the activity.
 - **Data access**: Especially when working with protected data, it’s important to ensure that users have proper authorization to view the data before giving them access to a Workspace containing the data.  Terra provides **Authorization Domains** to assist with this.
 
-In general we recommend:
-
-- **Writers: Lab members who need permission to compute** (and charge to your Billing Project).
-- **Readers: All other users** (i.e. users who need to see the Workspace but should not charge to your Billing Project).  Readers can always “clone” the Workspace (creating a copy of it associated with their own Billing Project) if they want to run computations themselves.
-- If working with protected data, take advantage of Authorization Domains to increase security.
-
 ```{r, echo=FALSE, fig.alt='Table summarizing Workspace permission levels.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_122")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1hhdPNfuAhbwkl5LlNVlJiCIx_rbzVp3jSJJeksqiR5I/edit#slide=id.g117dd5f15db_0_584")
 ```
 
 More details about the permissions associated with each Access Level can be found in the [Terra documentation](https://support.terra.bio/hc/en-us/articles/360025851892-Reader-writer-or-owner-Workspace-access-controls-explained).
+
+In general we recommend:
+
+- **Writers: Lab members who need permission to compute** (and charge to your Billing Project).  This gives them permission to freely use the Workspace, (adding and removing data, conducting analyses, etc.) but prevents them from adding additional members who could charge to your Billing Project, ensuring you have control over *who* is doing the spending.
+- **Readers: All other users** (i.e. users who need to see the Workspace but should not charge to your Billing Project).  Readers can always “clone” the Workspace (creating a copy of it associated with their own Billing Project) if they want to run computations themselves.
+- If working with protected data, take advantage of Authorization Domains to increase security.
+
+
+To add a member to a Workspace:
+
+```{r, child=c("_child_workspace_add_members.Rmd")}
+
+```
+
 
 ## Wrap-Up {#pis-wrap-up}
 

--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -226,7 +226,7 @@ Billing permissions on Terra can be confusing.  For this reason, **We recommend 
 
 ### Create a New Workspace
 
-```{r, child=c("_child_create_workspace.Rmd")}
+```{r, child=c("_child_workspace_create.Rmd")}
 
 ```
 

--- a/05-workspaces.Rmd
+++ b/05-workspaces.Rmd
@@ -18,6 +18,6 @@ Creating a new Workspace from scratch allows you to fully customize the contents
 
 Cloning an existing Workspace allows you to copy existing documentation, code, and/or data into your own experimental space. That following steps show you how to clone a Workspace that has already been developed by other AnVIL users. When cloning, AnVIL makes a copy of notebooks and code for you to modify. Data however, is linked back to the original Workspace through Data Tables, which saves space!
 
-```{r, child=c("_child_clone_workspace.Rmd")}
+```{r, child=c("_child_workspace_clone.Rmd")}
 
 ```

--- a/05-workspaces.Rmd
+++ b/05-workspaces.Rmd
@@ -10,7 +10,7 @@ Workspaces are the building blocks of projects in Terra. Inside a Workspace, you
 
 Creating a new Workspace from scratch allows you to fully customize the contents. The following steps show you how to create a Workspace so you can get started.
 
-```{r, child=c("_child_create_workspace.Rmd")}
+```{r, child=c("_child_workspace_create.Rmd")}
 
 ```
 

--- a/_child_workspace_add_members.Rmd
+++ b/_child_workspace_add_members.Rmd
@@ -1,0 +1,40 @@
+1. [Launch Terra](https://anvil.terra.bio/#workspaces)
+
+1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1hhdPNfuAhbwkl5LlNVlJiCIx_rbzVp3jSJJeksqiR5I/edit#slide=id.g117989bd49c_0_150")
+    ```
+
+1. Click on the name of the Workspace to open the Workspace. Opening a Workspace does not cost anything.  Certain activities in the Workspace (such as running an analysis) will charge to the Workspace’s Billing Project.  Workspace management (e.g. adding and removing members, editing the description) does not cost money.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspace page.  The name of a Workspace is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1hhdPNfuAhbwkl5LlNVlJiCIx_rbzVp3jSJJeksqiR5I/edit#slide=id.g117dd5f15db_0_289")
+    ```
+
+1. Click the circle with 3 dots on the right hand side to open the Workspace management menu.  Click "Share"
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of an individual Terra Workspace dashboard page.  The button for extending the Workspaces\'s drop-down menu is highlighted, and the menu item "Share" is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1hhdPNfuAhbwkl5LlNVlJiCIx_rbzVp3jSJJeksqiR5I/edit#slide=id.g117dd5f15db_0_295")
+    ```
+
+1. Enter the email address of the user you want to share the Workspace with.  This must be the address associated with the account they are using to access Terra.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The text box labeled "User email" is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1hhdPNfuAhbwkl5LlNVlJiCIx_rbzVp3jSJJeksqiR5I/edit#slide=id.g117dd5f15db_0_440")
+    ```
+
+1. Choose their permission level.
+
+    - Remember that all activity in the Workspace will be charged to the Workspace's Billing Project, regardless of who conducts it, so only add members as "Writers" or "Owners" if they should be charging to the Workspace's Billing Project.
+    - "Readers" can view all parts of the Workspace but cannot make edits or run analyses (i.e. they cannot spend money).  They can also clone their own copy of the Workspace where they can conduct activity on their own Billing Project.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The drop-down menu labeled with the email of the user you are sharing with is highlighted and the menu item "Writer" is selected.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1hhdPNfuAhbwkl5LlNVlJiCIx_rbzVp3jSJJeksqiR5I/edit#slide=id.g117dd5f15db_0_756")
+    ```
+
+1. Click "Save".  The user should now be able to see the Workspace when logged in to Terra.
+
+    ```{r, echo=FALSE, fig.alt='Screenshot of the dialog box for sharing a Terra Workspace.  The "Save" button is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1hhdPNfuAhbwkl5LlNVlJiCIx_rbzVp3jSJJeksqiR5I/edit#slide=id.g117dd5f15db_0_902")
+    ```

--- a/_child_workspace_clone.Rmd
+++ b/_child_workspace_clone.Rmd
@@ -3,44 +3,44 @@
 1. Locate the Workspace you want to clone. If a Workspace has been shared with you ahead of time, it will appear in "MY WORKSPACES". You can clone a Workspace that was shared with you to perform your own analyses. In the screenshot below, no Workspaces have been shared.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra "MY WORKSPACES" menu. The "MY WORKSPACES" tab is highlighted. No Workspaces are visible because none have been shared with the user. There is an option to create a new Workspace.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1ioYY0n3CcrP934WRKEsQ1aKocPqfswdWWHxYCf76BCg/edit#slide=id.gf5172664d7_0_142")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1JvfOluHe543cUCyyH3zz0ew-1J1QjhdYGZufW9NrC_M/edit#slide=id.g117abafa453_0_0")
     ```
 
 1. If a Workspace hasn't been shared with you, navigate to the "FEATURED" or "PUBLIC" Workspace tabs.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra "My Workspaces" menu. The "FEATURED" tab is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1ioYY0n3CcrP934WRKEsQ1aKocPqfswdWWHxYCf76BCg/edit#slide=id.gf5172664d7_0_335")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1JvfOluHe543cUCyyH3zz0ew-1J1QjhdYGZufW9NrC_M/edit#slide=id.g117abafa453_0_144")
     ```
     
 1. Use the search box to find the Workspace you want to clone.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra "My Workspaces" menu. The search bar is highlighted and the user has typed in the term "COVID-19". A Workspace related to COVID-19 appears in the results.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1ioYY0n3CcrP934WRKEsQ1aKocPqfswdWWHxYCf76BCg/edit#slide=id.gf5172664d7_0_342")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1JvfOluHe543cUCyyH3zz0ew-1J1QjhdYGZufW9NrC_M/edit#slide=id.g117abafa453_0_288")
     ```
     
 1. Click the teardrop button on the far right next to the Workspace you want to clone. Click "Clone". You can also clone the Workspace from the Workspace Dashboard instead of the search results.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra "My Workspaces" menu with the Workspace that we want to clone. The teardrop button has been clicked to bring up the options. The "Clone" option from the list is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1ioYY0n3CcrP934WRKEsQ1aKocPqfswdWWHxYCf76BCg/edit#slide=id.gf5172664d7_0_351")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1JvfOluHe543cUCyyH3zz0ew-1J1QjhdYGZufW9NrC_M/edit#slide=id.g117abafa453_0_432")
     ```
     ```{r, echo=FALSE, fig.alt='Screenshot of the Dashboard for the Workspace that we want to clone. The teardrop button has been clicked to bring up the options. The "Clone" option from the list is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1ioYY0n3CcrP934WRKEsQ1aKocPqfswdWWHxYCf76BCg/edit#slide=id.gf5172664d7_0_322")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1JvfOluHe543cUCyyH3zz0ew-1J1QjhdYGZufW9NrC_M/edit#slide=id.g117abafa453_0_577")
     ```
     
 1. You will see a popup box appear. Name your Workspace and select the appropriate Terra Billing Project.  **All activity in the Workspace will be charged to this Billing Project** (regardless of who conducted it). Remember that each Workspace should have its own Billing Project.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the "clone workspace" Terra popup dialog box. The Workspace name and Billing Project dropdown are highlighted. Text has been filled in for the Workspace name as "Lab-member-1-workspace-2".'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1ioYY0n3CcrP934WRKEsQ1aKocPqfswdWWHxYCf76BCg/edit#slide=id.gf5172664d7_0_288")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1JvfOluHe543cUCyyH3zz0ew-1J1QjhdYGZufW9NrC_M/edit#slide=id.g117abafa453_0_722")
     ```
 
 1. If you are working with protected data, you can set the **Authorization Domain** to limit who can be added to your Workspace.  Note that the Authorization Domain cannot be changed after the Workspace is created (i.e. there is no way to make this Workspace shareable with a larger audience in the future).  Workspaces by default are only visible to people you specifically share them with.  Authorization domains add an extra layer of enforcement over privacy, but by nature make sharing more complicated.  We recommend using Authorization Domains in cases where it is extremely important and/or legally required that the data be kept private (e.g. protected patient data, industry data).  For data you would merely prefer not be shared with the world, we recommend relying on standard Workspace sharing permissions rather than Authorization Domains, as Authorization Domains can make future collaborations, publications, or other sharing complicated.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra popup dialog box for creating a new Workspace. The drop-down menu labeled "Authorization domain" is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1ioYY0n3CcrP934WRKEsQ1aKocPqfswdWWHxYCf76BCg/edit#slide=id.gf5172664d7_0_313")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1JvfOluHe543cUCyyH3zz0ew-1J1QjhdYGZufW9NrC_M/edit#slide=id.g117abafa453_0_867")
     ```
     
 1. Click "CLONE WORKSPACE".  The new Workspace should now show up under your Workspaces.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra popup dialog box for creating a new Workspace. The "Clone Workspace" button is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1ioYY0n3CcrP934WRKEsQ1aKocPqfswdWWHxYCf76BCg/edit#slide=id.gf5172664d7_0_304")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1JvfOluHe543cUCyyH3zz0ew-1J1QjhdYGZufW9NrC_M/edit#slide=id.g117abafa453_0_1012")
     ```

--- a/_child_workspace_create.Rmd
+++ b/_child_workspace_create.Rmd
@@ -3,29 +3,29 @@
 1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_75")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1zyqZHITAthNhXeH2XQqA7FMOu2mek6wfgGEaje1KQsk/edit#slide=id.g117989bd49c_0_150")
     ```
 
 1. Click on the **plus icon** near the top of left of the page.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra Workspaces page.  The "+" is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_69")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1zyqZHITAthNhXeH2XQqA7FMOu2mek6wfgGEaje1KQsk/edit#slide=id.g117989bd49c_0_733")
     ```
 
 1. Name your Workspace and select the appropriate Billing Project.  **All activity in the Workspace will be charged to this Billing Project** (regardless of who conducted it).
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The text box labeled "Workspace name" and the drop-down menu labeled "Billing project" are highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_84")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1zyqZHITAthNhXeH2XQqA7FMOu2mek6wfgGEaje1KQsk/edit#slide=id.g117989bd49c_0_877")
     ```
 
 1. If you are working with protected data, you can set the **Authorization Domain** to limit who can be added to your Workspace.  Note that the Authorization Domain cannot be changed after the Workspace is created (i.e. there is no way to make this Workspace shareable with a larger audience in the future).  Workspaces by default are only visible to people you specifically share them with.  Authorization domains add an extra layer of enforcement over privacy, but by nature make sharing more complicated.  We recommend using Authorization Domains in cases where it is extremely important and/or legally required that the data be kept private (e.g. protected patient data, industry data).  For data you would merely prefer not be shared with the world, we recommend relying on standard Workspace sharing permissions rather than Authorization Domains, as Authorization Domains can make future collaborations, publications, or other sharing complicated.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The drop-down menu labeled "Authorization domain" is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_91")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1zyqZHITAthNhXeH2XQqA7FMOu2mek6wfgGEaje1KQsk/edit#slide=id.g117989bd49c_0_1022")
     ```
 
 1. Click "CREATE WORKSPACE".  The new Workspace should now show up under your Workspaces.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of Terra dialog box for creating a new Workspace.  The "Create Workspace" button is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/162GS7ArBPM4w_rPazcUrpnoEKT7jx9i7fpPQkH_iC_0/edit#slide=id.gda79c11827_0_97")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1zyqZHITAthNhXeH2XQqA7FMOu2mek6wfgGEaje1KQsk/edit#slide=id.g117989bd49c_0_1166")
     ```


### PR DESCRIPTION
Mostly this was just pointing to new slidedecks so that doesn't really need review, there's no change to the book content.

But in order to pull out the "Add Members to Workspace" section into an independent, reusable child document I had to do a bit of rearranging, so, if someone could look over section 2.7.2, that would be great!