### PR TITLE
add Google Project quota increase

### DIFF
--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -254,7 +254,7 @@ cow::borrow_chapter(
 )
 ```
 
-**To start, we recommend creating one Workspace for each lab member** (associated with that lab member’s Billing Project, with separate Billing Projects for your lab members).  This will enable you and your lab members to familiarize yourself with Workspaces and decide how best to organize your work.  You can then create additional Workspaces as needed (there are no limits on the number of Workspaces).
+**To start, we recommend creating one Workspace for each lab member** (associated with that lab member’s Billing Project, with separate Billing Projects for your lab members).  This will enable you and your lab members to familiarize yourself with Workspaces and decide how best to organize your work.  You can then create additional Workspaces as needed.
 
 ### Add Members to Workspaces
 

--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -300,7 +300,7 @@ To prevent abuse, new users of GCP are only permitted to create a few Google Clo
 
 Since this limit is imposed by Google, you will need to contact them directly to request a quota increase, using [this form](https://support.google.com/code/contact/billing_quota_increase).
 
-As the time of writing (May 2022) Terra is working to expedite this process for Terra users; we recommend checking the [relevant Terra documentation](https://support.terra.bio/hc/en-us/articles/360029071251#h_01FFNCK82NB0YMAH5BTP41GYSY) for the latest information as well as recommendations about how to fill out the form.
+At the time of writing (April 2022) Terra is working to expedite this process for Terra users; we recommend checking the [relevant Terra documentation](https://support.terra.bio/hc/en-us/articles/360029071251#h_01FFNCK82NB0YMAH5BTP41GYSY) for the latest information as well as recommendations about how to fill out the form.
 
 ## Wrap-Up {#pis-wrap-up}
 

--- a/02-pis.Rmd
+++ b/02-pis.Rmd
@@ -294,6 +294,14 @@ cow::borrow_chapter(
 ```
 
 
+### Request Quota Increase
+
+To prevent abuse, new users of GCP are only permitted to create a few Google Cloud "Projects".  When working on Terra, each Terra Workspace is associated with its own Google Cloud Project, so if your team has multiple members you can bump up against this limit fairly quickly and won't be able to create more Workspaces.
+
+Since this limit is imposed by Google, you will need to contact them directly to request a quota increase, using [this form](https://support.google.com/code/contact/billing_quota_increase).
+
+As the time of writing (May 2022) Terra is working to expedite this process for Terra users; we recommend checking the [relevant Terra documentation](https://support.terra.bio/hc/en-us/articles/360029071251#h_01FFNCK82NB0YMAH5BTP41GYSY) for the latest information as well as recommendations about how to fill out the form.
+
 ## Wrap-Up {#pis-wrap-up}
 
 **Congratulations!  You have successfully set up AnVIL for your lab!**

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -13,6 +13,7 @@ CMG
 Computability
 dbGaP
 Dockstore
+dropdown
 DUAs
 eMERGE
 eRA


### PR DESCRIPTION
Adding 2.7.3 - short blurb letting people know about the Google Project quota limit and directing them to Terra docs for the latest advice on requesting more (since those are likely more up-to-date).

I didn't bother making this a child document since it's mostly an explanation of "why you need to do this" (which I think is better if it's contextualized to the relevant persona), plus a couple of links.

Closes #99 