### PR TITLE
Update style.css for click to expand boxes

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -436,3 +436,13 @@ a.anchor:hover {
   font-size: .85em;
   color: #193a5c;
 }
+
+/* Click to Expand Details Boxes */
+
+.click_to_expand_block {
+    padding: 1em;
+    padding-top: .5em;
+    border: 1px grey;
+    background: #E8E8E8;
+    color: black;
+}


### PR DESCRIPTION
Noticed that the click to expand styling/content box I had in AnVIL Template wasn't carried over when I incorporated the Why AnVIL chapter, so bringing the styling chunk over here to see if rendering captures that now
<img width="870" height="214" alt="image" src="https://github.com/user-attachments/assets/b4883401-a17b-4066-a313-b914d70bbbe9" />
